### PR TITLE
Add a bit more description

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# powdrVM Usager/Integration/Practitioner’s/Utility template
+# powdrVM Usage Template
 
 This is a foundational template for developing and running zero-knowledge proofs on powdrVM. To prove code using PowdrVM, you need to write the code you want to be proven as a guest program for the zkVM host. This template includes a structure for host/guest interaction, ZKP setup, and artifact generation.
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This is a foundational template for generating zero-knowledge proofs with powdrVM. You write the code to be proven as a guest program for the zkVM host. This template includes a structure for host/guest interaction, ZKP setup, and artifact generation.
 
 
-Guest programs are written in Rust. When creating your guest program, you can write Rust code in the usual way, including using std and importing packages others have written. We provide some additional zkVM-specific functionality, most notably powdr_riscv_runtime::io::read for reading the input data.
+Guest programs are written in Rust. When creating your guest program, you can write Rust code in the usual way, including using std and importing packages others have written. We provide some additional powdrVM specific functionalities via system calls, such as IO operations for host <-> guest communication and precompiles to accelerate complex programs via optimized circuits.
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
-# powdrVM template
+# powdrVM Usager/Integration/Practitioner’s/Utility template
 
-This template is a basic structure for a powdrVM host/guest project.
+This is a foundational template for developing and running zero-knowledge proofs on powdrVM. To prove code using PowdrVM, you need to write the code you want to be proven as a guest program for the zkVM host. This template includes a structure for host/guest interaction, ZKP setup, and artifact generation.
+
+
+Guest programs are written in Rust. When creating your guest program, you can write Rust code in the usual way, including using std and importing packages others have written. We provide some additional zkVM-specific functionality, most notably powdr_riscv_runtime::io::read for reading the input data.
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # powdrVM Usage Template
 
-This is a foundational template for developing and running zero-knowledge proofs on powdrVM. To prove code using PowdrVM, you need to write the code you want to be proven as a guest program for the zkVM host. This template includes a structure for host/guest interaction, ZKP setup, and artifact generation.
+This is a foundational template for generating zero-knowledge proofs with powdrVM. You write the code to be proven as a guest program for the zkVM host. This template includes a structure for host/guest interaction, ZKP setup, and artifact generation.
 
 
 Guest programs are written in Rust. When creating your guest program, you can write Rust code in the usual way, including using std and importing packages others have written. We provide some additional zkVM-specific functionality, most notably powdr_riscv_runtime::io::read for reading the input data.


### PR DESCRIPTION
Add more descriptions in Readme.
Giving several name candidates for the template, "powdrVM Usager/Integration/Practitioner’s/Utility template" but maybe it is more than necessary to be so concrete. 
Clarified host/guest terms based on [RISC Zero docs](https://dev.risczero.com/api/0.20/bonsai/blockchain-zkvm-guide) to assist newcomers. Updated template overview to highlight the foundational structure for host/guest interactions, ZKP setup, and artifact generation. These additions aim to support usability, again, maybe some elements may already be too fundamental to be clarified ^^' 