### PR TITLE
Fix powdr feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [features]
 default = []
-simd = ["powdr/simd"]
+simd = ["powdr/plonky3-simd", "powdr/estark-starky-simd"]
 
 [dependencies]
 powdr = { git = "https://github.com/powdr-labs/powdr", features = ["plonky3"] }


### PR DESCRIPTION
Without this change, I get:
```
$ cargo run -r
error: failed to select a version for `powdr`.
    ... required by package `my-powdr-host v0.1.0 (/Users/georg/coding/powdr-template)`
versions that meet the requirements `*` (locked to 0.1.0-alpha.2) are: 0.1.0-alpha.2

the package `my-powdr-host` depends on `powdr`, with features: `simd` but `powdr` does not have these features.


failed to select a version for `powdr` which could resolve this conflict
```